### PR TITLE
Add --strict-symbol-lookup flag

### DIFF
--- a/Sources/Clue/ClueEngine.swift
+++ b/Sources/Clue/ClueEngine.swift
@@ -53,13 +53,14 @@ public enum ClueEngine {
         symbolName: String,
         module: String?,
         kind: IndexSymbolKind?,
-        isSystem: Bool
+        isSystem: Bool,
+        strictSymbolLookup: Bool
     ) throws -> SymbolOccurrence {
         let candidates = db
             .canonicalOccurrences(
                 containing: symbolName,
                 anchorStart: true,
-                anchorEnd: false, // TODO: give user the option to customize this value
+                anchorEnd: strictSymbolLookup,
                 subsequence: false,
                 ignoreCase: false
             )
@@ -108,13 +109,14 @@ public enum ClueEngine {
             }
 
             definition = candidates[0]
-        case .query(let symbol, let module, let kind, let isSystem):
+        case .query(let symbol, let module, let kind, let isSystem, let strictSymbolLookup):
             definition = try self.inferReferenceQuerySymbol(
                 db: db,
                 symbolName: symbol,
                 module: module,
                 kind: kind,
-                isSystem: isSystem
+                isSystem: isSystem,
+                strictSymbolLookup: strictSymbolLookup
             )
         }
 

--- a/Sources/Clue/USRQuery.swift
+++ b/Sources/Clue/USRQuery.swift
@@ -7,6 +7,7 @@ public enum USRQuery {
         symbol: String,
         module: String? = nil,
         kind: IndexSymbolKind? = nil,
-        isSystem: Bool
+        isSystem: Bool,
+        strictSymbolLookup: Bool
     )
 }

--- a/Sources/clue-cli/Options.swift
+++ b/Sources/clue-cli/Options.swift
@@ -65,6 +65,9 @@ struct Options: ParsableCommand {
     @Flag(help: "Whether `symbol` is a system symbol.")
     var isSystem: Bool = false
 
+    @Flag(help: "Treat `symbol` as full name. Note for functions this include parameters like f(a:b:)")
+    var strictSymbolLookup: Bool = false
+
     @Argument(help: "Name of a symbol to look for. Cannot be used with `usr` at the same time.")
     var symbol: String?
 }

--- a/Sources/clue-cli/main.swift
+++ b/Sources/clue-cli/main.swift
@@ -75,7 +75,8 @@ func usrQueryFrom(_ options: Options) -> USRQuery {
             symbol: symbolName,
             module: options.module,
             kind: symbolKindFrom(options),
-            isSystem: options.isSystem
+            isSystem: options.isSystem,
+            strictSymbolLookup: options.strictSymbolLookup
         )
     case let (.some(usr), nil):
         return .explict(usr: usr)

--- a/Tests/ClueTests/ClueTests.swift
+++ b/Tests/ClueTests/ClueTests.swift
@@ -47,7 +47,7 @@ final class ClueTests: XCTestCase {
                            file: StaticString = #file, line: UInt = #line) throws
     {
         try self.verifyQuery(
-            usr: .query(symbol: symbolName, isSystem: false),
+            usr: .query(symbol: symbolName, isSystem: false, strictSymbolLookup: false),
             role: role,
             expectedDefinition: expectedDefinition,
             expectedPaths: expectedPaths,


### PR DESCRIPTION
When this is set, partial symbol names will not match as prefix of the
definition symbol's name.