### PR TITLE
Update symbol role separator

### DIFF
--- a/Sources/clue-cli/SymbolRole+Extensions.swift
+++ b/Sources/clue-cli/SymbolRole+Extensions.swift
@@ -127,6 +127,6 @@ extension SymbolRole {
                 result.append(role.singleRoleDescription)
             }
         }
-        return result.joined(separator: ", ")
+        return result.joined(separator: "|")
     }
 }


### PR DESCRIPTION
The comma isn't very useful in CSV output format.
